### PR TITLE
Bug fix: Use string concatenation

### DIFF
--- a/daisy/scheduler.py
+++ b/daisy/scheduler.py
@@ -187,7 +187,7 @@ class Scheduler():
 
         if worker not in self.worker_type:
             logger.error(
-                "Worker %s closed before finished initializing. ",
+                "Worker %s closed before finished initializing. " \
                 "It will not be respawned.",
                 worker
             )

--- a/daisy/scheduler.py
+++ b/daisy/scheduler.py
@@ -187,7 +187,7 @@ class Scheduler():
 
         if worker not in self.worker_type:
             logger.error(
-                "Worker %s closed before finished initializing. " \
+                "Worker %s closed before finished initializing. "
                 "It will not be respawned.",
                 worker
             )


### PR DESCRIPTION
Logging throws errors like this:
```
--- Logging error ---
Traceback (most recent call last):
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/logging/__init__.py", line 994, in emit
    msg = self.format(record)
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/logging/__init__.py", line 840, in format
    return fmt.format(record)
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/logging/__init__.py", line 577, in format
    record.message = record.getMessage()
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/logging/__init__.py", line 338, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/threading.py", line 884, in _bootstrap
    self._bootstrap_inner()
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/site-packages/tornado/platform/asyncio.py", line 132, in start
    self.asyncio_loop.run_forever()
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/asyncio/base_events.py", line 438, in run_forever
    self._run_once()
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/asyncio/base_events.py", line 1451, in _run_once
    handle._run()
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/site-packages/daisy/tcp.py", line 83, in handle_stream
    self.scheduler.remove_worker_callback(worker)
  File "/groups/saalfeld/home/hanslovskyp/miniconda3/lib/python3.6/site-packages/daisy/scheduler.py", line 192, in remove_worker_callback
    worker
Message: 'Worker %s closed before finished initializing. '
Arguments: ('It will not be respawned.', 1 at 10.40.2.114:49798)
```

This was probably [`string concatenation` without operator](https://stackoverflow.com/questions/18842779/string-concatenation-without-operator) for string literals at some point.