### PR TITLE
Bugfix mongo metadata collection

### DIFF
--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -457,12 +457,27 @@ class MongoDbGraphProvider(SharedGraphProvider):
 
         self.__open_collections()
         metadata = self.__get_metadata()
-        if self.directed is not None and metadata['directed'] != self.directed:
+        if self.directed is None:
+            assert metadata['directed'] is not None,\
+                "Meta collection exists but does not contain "\
+                "directed information"
+            self.directed = metadata['directed']
+        elif metadata['directed'] != self.directed:
             raise ValueError((
                     "Input parameter directed={} does not match"
                     "directed value {} already in stored metadata")
                     .format(self.directed, metadata['directed']))
-        if self.total_roi:
+        if self.total_roi is None:
+            offset = metadata['total_roi_offset']
+            shape = metadata['total_roi_shape']
+            assert offset is not None,\
+                "Meta collection exists but does not contain "\
+                "total roi offset information"
+            assert shape is not None,\
+                "Meta collection exists but does not contain "\
+                "total roi shape information"
+            self.total_roi = Roi(offset, shape)
+        else:
             offset = self.total_roi.get_offset()
             if list(offset) != metadata['total_roi_offset']:
                 raise ValueError((

--- a/daisy/tests/test_graph_meta_collection.py
+++ b/daisy/tests/test_graph_meta_collection.py
@@ -1,0 +1,55 @@
+import daisy
+import unittest
+
+
+class TestMetaCollection(unittest.TestCase):
+
+    def get_mongo_graph_provider(self, mode, directed, total_roi):
+        return daisy.persistence.MongoDbGraphProvider(
+            'test_daisy_graph',
+            directed=directed,
+            total_roi=total_roi,
+            mode=mode)
+
+    def test_graph_read_meta_values(self):
+        roi = daisy.Roi((0, 0, 0),
+                        (10, 10, 10))
+        self.get_mongo_graph_provider(
+                'w', True, roi)
+
+        graph_provider = self.get_mongo_graph_provider(
+                'r', None, None)
+
+        self.assertEqual(True, graph_provider.directed)
+        self.assertEqual(roi, graph_provider.total_roi)
+
+    def test_graph_default_meta_values(self):
+        provider = self.get_mongo_graph_provider(
+                'w', None, None)
+        self.assertEqual(False, provider.directed)
+        self.assertIsNone(provider.total_roi)
+
+        graph_provider = self.get_mongo_graph_provider(
+                'r', None, None)
+
+        self.assertEqual(False, graph_provider.directed)
+        self.assertIsNone(graph_provider.total_roi)
+
+    def test_graph_nonmatching_meta_values(self):
+        roi = daisy.Roi((0, 0, 0),
+                        (10, 10, 10))
+        roi2 = daisy.Roi((1, 0, 0),
+                         (10, 10, 10))
+        self.get_mongo_graph_provider(
+                'w', True, None)
+
+        with self.assertRaises(ValueError):
+            self.get_mongo_graph_provider(
+                'r', False, None)
+
+        self.get_mongo_graph_provider(
+                'w', None, roi)
+
+        with self.assertRaises(ValueError):
+            self.get_mongo_graph_provider(
+                'r', None, roi2)


### PR DESCRIPTION
@funkey I forgot to read the metadata values out of the meta collection if they are not specified, which definitely explains the directed=None without needing a race condition. Since you can't actually control the locks on a mongo collection (despite my confident assertions that you must be able to!), I didn't create a complicated solution to a problem that may or may not happen. I did put in asserts that will detect if the race condition becomes a problem, and we can fix it if it's actually an issue.