### PR TITLE
Make a compound index rather than multikey index

### DIFF
--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -102,6 +102,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
         self.edges = None
         self.meta = None
         self.position_attribute = position_attribute
+        self.dims = dims
 
         try:
 

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -84,7 +84,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
             endpoint_names=None,
             meta_collection='meta',
             position_attribute='position',
-            dims=3):
+            dims=None):
 
         self.db_name = db_name
         self.host = host

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -65,10 +65,10 @@ class MongoDbGraphProvider(SharedGraphProvider):
 
         dims (``int``):
 
-            The number of dimensions of the data stored in the "position_attribute".
-            Only needed if "position_attribute" is a single value e.g. "position"
-            to create the valid number of attributes e.g. "position.0", "position.1",
-            "position.2"
+            The number of dimensions of the data stored in the
+            "position_attribute". Only needed if "position_attribute" is a
+            single value e.g. "position" to create the valid number of
+            attributes e.g. "position.0", "position.1", "position.2"
 
     '''
 

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -63,6 +63,13 @@ class MongoDbGraphProvider(SharedGraphProvider):
             entry denotes the position coordinates in order (e.g.,
             `position_z`, `position_y`, `position_x`).
 
+        dims (``int``):
+
+            The number of dimensions of the data stored in the "position_attribute".
+            Only needed if "position_attribute" is a single value e.g. "position"
+            to create the valid number of attributes e.g. "position.0", "position.1",
+            "position.2"
+
     '''
 
     def __init__(
@@ -76,7 +83,8 @@ class MongoDbGraphProvider(SharedGraphProvider):
             edges_collection='edges',
             endpoint_names=None,
             meta_collection='meta',
-            position_attribute='position'):
+            position_attribute='position',
+            dims=3):
 
         self.db_name = db_name
         self.host = host
@@ -475,7 +483,8 @@ class MongoDbGraphProvider(SharedGraphProvider):
         else:
             self.nodes.create_index(
                 [
-                    ('position', ASCENDING)
+                    ('position.%s' % i, ASCENDING)
+                    for i in range(self.dims)
                 ],
                 name='position')
 

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -483,7 +483,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
         else:
             self.nodes.create_index(
                 [
-                    ('position.%s' % i, ASCENDING)
+                    ('%s.%s' % (self.position_attribute, i), ASCENDING)
                     for i in range(self.dims)
                 ],
                 name='position')

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -475,12 +475,21 @@ class MongoDbGraphProvider(SharedGraphProvider):
         self.__open_collections()
 
         if isinstance(self.position_attribute, str):
-            self.nodes.create_index(
-                [
-                    ('%s.%s' % (self.position_attribute, i), ASCENDING)
-                    for i in range(self.dims)
-                ],
-                name='position')
+            if self.dims is None:
+                logger.warning("Recommended to provide number of dimensions "
+                               "for efficient position indexing")
+                self.nodes.create_index(
+                        [
+                            (self.position_attribute, ASCENDING)
+                        ],
+                        name='position')
+            else:
+                self.nodes.create_index(
+                    [
+                        ('%s.%s' % (self.position_attribute, i), ASCENDING)
+                        for i in range(self.dims)
+                    ],
+                    name='position')
         else:
             self.nodes.create_index(
                 [


### PR DESCRIPTION
It seems like multikey indicies behave like a single "axis". This makes it very
easy to find all documents that have any coordinate with a range,
but when querying individual axes, MongoDb reverts to a slow COLLSCAN.

Solution:
This can be fixed by making a compound index, using each axis
as a key for a new index.
Wierd note: MongoDb seems to revert to a COLLSCAN if no bound is
given for the first key in the compound index.