### PR TITLE
Dangling attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ Daisy is not a mapreduce framework. It reduces overhead by only sending coordina
 ## API:
 See docs at https://daisy-doc.readthedocs.io
 
-
+## Examples:
+See examples folder for some basic examples of using daisy for blockwise processing.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Daisy: A Blockwise Task Scheduler
+
+> Blockwise task scheduler for processing large volumetric data
+
+## What is Daisy?
+Daisy is a lightweight blockwise task scheduler for processing n-D volumes in parallel.
+Daisy is not a mapreduce framework. It reduces overhead by only sending coordinates and status checks between the scheduler and the worker. Each worker is responsible for reading from and writing to data stores in specified locations.
+
+## Features of Daisy:
+ - Representations of regions in a volume in real world units, easily handling voxel sizes, with convenience functions for region manipulation (intersection, union, growing or shrinking, etc.)
+ - Daisy array interface that can wrap any object with a shape attribute and slicing operations (zarr, hdf5, numpy array)
+ - Daisy geometric graph interface with support for file system and MongoDB storage (nodes are locations in space, and can be accessed by region)
+ - Easy specification of inter-block dependencies (can ensure one worker won't read from a region while another worker is writing to it)
+ - Worker initialization once per task, rather than once per block, to reduce overhead
+ - Task chaining for running multiple steps in a pipeline
+
+## API:
+See docs at https://daisy-doc.readthedocs.io
+
+

--- a/daisy/array.py
+++ b/daisy/array.py
@@ -144,8 +144,8 @@ class Array(Freezable):
             coordinate = key
 
             assert self.roi.contains(coordinate), (
-                "Requested coordinate (%s) is not contained in this array (%s)." % (
-                    coordinate, self.roi))
+                "Requested coordinate (%s) is not contained "
+                "in this array (%s)." % (coordinate, self.roi))
 
             return self.data[self.__index(coordinate)]
 

--- a/daisy/array.py
+++ b/daisy/array.py
@@ -124,7 +124,8 @@ class Array(Freezable):
             coordinate = key
 
             assert self.roi.contains(coordinate), (
-                "Requested coordinate is not contained in this array.")
+                "Requested coordinate (%s) is not contained in this array (%s)." % (
+                    coordinate, self.roi))
 
             return self.data[self.__index(coordinate)]
 

--- a/daisy/block.py
+++ b/daisy/block.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import
 from .coordinate import Coordinate
 from .freezable import Freezable
-from funlib.math import cantor_number
+from funlib.math import cantor_number, inv_cantor_number
+from .roi import Roi
 import copy
+import itertools
 
 
 class Block(Freezable):
+
     '''Describes a block to process with attributes:
 
     Attributes:
@@ -51,7 +54,7 @@ class Block(Freezable):
         self.write_roi = write_roi
 
         if block_id is None:
-            self.block_id, self.z_order_id = self.__compute_block_id(
+            self.block_id, self.z_order_id = self.compute_block_id(
                     total_roi, write_roi)
         else:
             self.block_id = block_id
@@ -62,11 +65,37 @@ class Block(Freezable):
 
         return copy.deepcopy(self)
 
-    def __compute_block_id(self, total_roi, write_roi, shift=None):
+    # Class variables to indicate fixes for cantor numbers.
+    # Some datasets were processed with cantor number starting from 1
+    # instead of from 0
+    BLOCK_ID_ADD_ONE_FIX = None
+    BLOCK_ID_SUB_ONE_FIX = None
+
+    @staticmethod
+    def index2id(block_index):
+
+        block_id = int(cantor_number(block_index))
+        if Block.BLOCK_ID_SUB_ONE_FIX:
+            block_id = block_id - 1
+        elif Block.BLOCK_ID_ADD_ONE_FIX:
+            block_id = block_id + 1
+        return block_id
+
+    @staticmethod
+    def id2index(block_id):
+
+        if Block.BLOCK_ID_SUB_ONE_FIX:
+            block_id = block_id + 1
+        elif Block.BLOCK_ID_ADD_ONE_FIX:
+            block_id = block_id - 1
+        return inv_cantor_number(block_id)
+
+    def compute_block_id(self, total_roi, write_roi, shift=None):
+
         block_index = write_roi.get_offset() / write_roi.get_shape()
 
         # block_id will be the cantor number for this block index
-        block_id = int(cantor_number(block_index))
+        block_id = Block.index2id(block_index)
 
         # calculating Z-order index
         # this index is inexact and is shape agnostic to promote maximum
@@ -94,3 +123,52 @@ class Block(Freezable):
             self.block_id,
             self.read_roi,
             self.write_roi)
+
+    @staticmethod
+    def get_chunks(
+            block,
+            chunk_div=None,
+            chunk_shape=None):
+        '''Convenient function to divide the given `block` into sub-blocks'''
+
+        if chunk_shape is None:
+            chunk_div = Coordinate(chunk_div)
+
+            for j, k in zip(block.write_roi.get_shape(), chunk_div):
+                assert (j % k) == 0
+
+            chunk_shape = block.write_roi.get_shape() / Coordinate(chunk_div)
+
+        else:
+            chunk_shape = Coordinate(chunk_shape)
+
+        write_offsets = itertools.product(*[
+            range(
+                block.write_roi.get_begin()[d],
+                block.write_roi.get_end()[d],
+                chunk_shape[d]
+                )
+            for d in range(chunk_shape.dims())
+        ])
+
+        context_begin = block.write_roi.get_begin()-block.read_roi.get_begin()
+        context_end = block.read_roi.get_end()-block.write_roi.get_end()
+
+        dummy_total_roi = Roi((0,)*chunk_shape.dims(),
+                              (0,)*chunk_shape.dims())
+        chunk_roi = Roi((0,)*chunk_shape.dims(), chunk_shape)
+        blocks = []
+
+        for write_offset in write_offsets:
+            write_roi = chunk_roi.shift(write_offset).intersect(
+                block.write_roi)
+            read_roi = write_roi.grow(context_begin, context_end).intersect(
+                block.read_roi)
+
+            if not write_roi.empty():
+                chunk = Block(dummy_total_roi,
+                              read_roi,
+                              write_roi)
+                blocks.append(chunk)
+
+        return blocks

--- a/daisy/blocks.py
+++ b/daisy/blocks.py
@@ -184,8 +184,8 @@ def compute_level_stride(block_read_roi, block_write_roi):
     # multiple of write shape
     write_shape = block_write_roi.get_shape()
     level_stride = Coordinate((
-        ((l - 1)//w + 1)*w
-        for l, w in zip(min_level_stride, write_shape)
+        ((level - 1)//w + 1)*w
+        for level, w in zip(min_level_stride, write_shape)
     ))
 
     logger.debug(

--- a/daisy/datasets.py
+++ b/daisy/datasets.py
@@ -67,7 +67,7 @@ def _read_voxel_size_offset(ds, order='C'):
     return Coordinate(voxel_size), Coordinate(offset)
 
 
-def open_ds(filename, ds_name, mode='r', attr_filename=None):
+def open_ds(filename, ds_name, mode='r', attr_filename=None, nested=False):
     '''Open a Zarr, N5, or HDF5 dataset as a :class:`daisy.Array`. If the
     dataset has attributes ``resolution`` and ``offset``, those will be
     used to determine the meta-information of the returned array.
@@ -97,7 +97,12 @@ def open_ds(filename, ds_name, mode='r', attr_filename=None):
 
         logger.debug("opening zarr dataset %s in %s", ds_name, filename)
         try:
-            ds = zarr.open(filename, mode=mode)[ds_name]
+            if nested:
+                # Use nested directories
+                store = zarr.NestedDirectoryStore(filename)
+            else:
+                store = zarr.DirectoryStore(filename)
+            ds = zarr.open_group(store=store, mode=mode)[ds_name]
         except Exception as e:
             logger.error("failed to open %s/%s" % (filename, ds_name))
             raise e

--- a/daisy/datasets.py
+++ b/daisy/datasets.py
@@ -93,6 +93,8 @@ def open_ds(filename, ds_name, mode='r', attr_filename=None):
         A :class:`daisy.Array` pointing to the dataset.
     '''
 
+    filename = filename.rstrip('/')
+
     if filename.endswith('.zarr'):
 
         logger.debug("opening zarr dataset %s in %s", ds_name, filename)

--- a/daisy/datasets.py
+++ b/daisy/datasets.py
@@ -67,7 +67,7 @@ def _read_voxel_size_offset(ds, order='C'):
     return Coordinate(voxel_size), Coordinate(offset)
 
 
-def open_ds(filename, ds_name, mode='r', attr_filename=None, nested=False):
+def open_ds(filename, ds_name, mode='r', attr_filename=None):
     '''Open a Zarr, N5, or HDF5 dataset as a :class:`daisy.Array`. If the
     dataset has attributes ``resolution`` and ``offset``, those will be
     used to determine the meta-information of the returned array.
@@ -97,12 +97,7 @@ def open_ds(filename, ds_name, mode='r', attr_filename=None, nested=False):
 
         logger.debug("opening zarr dataset %s in %s", ds_name, filename)
         try:
-            if nested:
-                # Use nested directories
-                store = zarr.NestedDirectoryStore(filename)
-            else:
-                store = zarr.DirectoryStore(filename)
-            ds = zarr.open_group(store=store, mode=mode)[ds_name]
+            ds = zarr.open(filename, mode=mode)[ds_name]
         except Exception as e:
             logger.error("failed to open %s/%s" % (filename, ds_name))
             raise e

--- a/daisy/datasets.py
+++ b/daisy/datasets.py
@@ -67,7 +67,7 @@ def _read_voxel_size_offset(ds, order='C'):
     return Coordinate(voxel_size), Coordinate(offset)
 
 
-def open_ds(filename, ds_name, mode='r', attr_filename=None, nested=False):
+def open_ds(filename, ds_name, mode='r', attr_filename=None):
     '''Open a Zarr, N5, or HDF5 dataset as a :class:`daisy.Array`. If the
     dataset has attributes ``resolution`` and ``offset``, those will be
     used to determine the meta-information of the returned array.
@@ -97,12 +97,7 @@ def open_ds(filename, ds_name, mode='r', attr_filename=None, nested=False):
 
         logger.debug("opening zarr dataset %s in %s", ds_name, filename)
         try:
-            if nested:
-                # Use nested directories
-                store = zarr.NestedDirectoryStore(filename)
-            else:
-                store = zarr.DirectoryStore(filename)
-            ds = zarr.open_group(store=store, mode=mode)[ds_name]
+            ds = zarr.open_group(filename, mode=mode)[ds_name]
         except Exception as e:
             logger.error("failed to open %s/%s" % (filename, ds_name))
             raise e
@@ -184,7 +179,8 @@ def prepare_ds(
         num_channels=1,
         compressor='default',
         delete=False,
-        force_exact_write_size=False):
+        force_exact_write_size=False,
+        nested=False):
     '''Prepare a Zarr or N5 dataset.
 
     Args:
@@ -290,12 +286,17 @@ def prepare_ds(
             chunk_shape = Coordinate((num_channels,) + chunk_shape)
         voxel_size_with_channels = Coordinate((1,) + voxel_size)
 
+    if nested:
+        logger.debug("Using nested directory structure")
+        store = zarr.NestedDirectoryStore(filename)
+    else:
+        store = zarr.DirectoryStore(filename)
+
     if not os.path.isdir(filename):
 
         logger.info("Creating new %s", filename)
         os.makedirs(filename)
-
-        zarr.open(filename, mode='w')
+        zarr.open(store=store, mode='w')
 
     if not os.path.isdir(os.path.join(filename, ds_name)):
 
@@ -304,7 +305,7 @@ def prepare_ds(
         if compressor is not None:
             compressor = zarr.get_codec(compressor)
 
-        root = zarr.open(filename, mode='a')
+        root = zarr.open(store=store, mode='a')
         ds = root.create_dataset(
             ds_name,
             shape=shape,

--- a/daisy/klb_adaptor.py
+++ b/daisy/klb_adaptor.py
@@ -5,6 +5,9 @@ import glob
 import json
 import numpy as np
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class KlbAdaptor():
@@ -17,35 +20,51 @@ class KlbAdaptor():
         if len(self.files) == 0:
             raise IOError("no KLB files found that match %s" % filename)
 
-        if attr_filename is None:
-            attr_filename = 'attributes.json'
-
-        attributes_file = os.path.join(
-            os.path.split(filename)[0],
-            attr_filename)
-
-        if not os.path.isfile(attributes_file):
-            raise IOError(
-                "no attributes file %s found next to %s"
-                % (attr_filename, filename))
-
-        with open(attributes_file, 'r') as f:
-
-            attributes = json.load(f)
-            self.voxel_size = Coordinate(attributes['resolution'])
-
-            self.shape = Coordinate(attributes['shape'])
-            offset = Coordinate(attributes['offset'])
-
-            self.roi = Roi(
-                offset,
-                self.shape*self.voxel_size)
-
         header = pyklb.readheader(self.files[0])
         self.dtype = header['datatype']
+        resolution_tzyx = np.delete(header['pixelspacing_tczyx'], 1)
+        blocksize_tzyx = np.delete(header['blocksize_tczyx'], 1)
+        imagesize_tzyx = np.delete(header['imagesize_tczyx'], 1)
+        self.voxel_size = Coordinate(resolution_tzyx)
+        self.chunk_shape = Coordinate(blocksize_tzyx)
+        self.shape = Coordinate(imagesize_tzyx)
+        offset = Coordinate((0,)*len(self.shape))
+        logger.debug("Found voxel size %s from header" % str(self.voxel_size))
+        logger.debug("Found chunk_shape %s from header"
+                     % str(self.chunk_shape))
+        logger.debug("Found shape %s from header" % str(self.shape))
 
-        # TODO: get chunk shape from KLB headers
-        self.chunk_shape = None
+        if attr_filename is not None:
+            logger.debug("Using attributes from file %s" % attr_filename)
+            attributes_file = os.path.join(
+                os.path.split(filename)[0],
+                attr_filename)
+
+            if not os.path.isfile(attributes_file):
+                raise IOError(
+                    "no attributes file %s found next to %s"
+                    % (attr_filename, filename))
+
+            with open(attributes_file, 'r') as f:
+
+                attributes = json.load(f)
+                if 'resolution' in attributes:
+                    self.voxel_size = Coordinate(attributes['resolution'])
+                    logger.debug("Overwriting voxel size with %s "
+                                 % str(self.voxel_size))
+                if 'shape' in attributes:
+                    self.shape = Coordinate(attributes['shape'])
+                    logger.debug("Overwriting shape with %s "
+                                 % str(self.shape))
+                if 'offset' in attributes:
+                    offset = Coordinate(attributes['offset'])
+                    logger.debug("Setting offset to %s "
+                                 % str(offset))
+
+        self.roi = Roi(
+            offset,
+            self.shape*self.voxel_size)
+        logger.debug("Using ROI %s" % str(self.roi))
 
     def __getitem__(self, slices):
 

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -251,7 +251,15 @@ class MongoDbGraphProvider(SharedGraphProvider):
 
         return False
 
-    def read_edges(self, roi, nodes=None, attr_filter=None, read_attrs=None, targeting_edges=False, dangling_attrs=False):
+    def read_edges(
+        self,
+        roi,
+        nodes=None,
+        attr_filter=None,
+        read_attrs=None,
+        targeting_edges=False,
+        dangling_attrs=False
+    ):
         '''Returns a list of edges within roi.
         Arguments:
 
@@ -347,7 +355,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
             logger.debug("first 100 edges read: %s", edges[:100])
 
             if dangling_attrs:
-            
+
                 node_ids = set(node_ids)
                 to_fetch = []
                 for edge in edges:

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -257,6 +257,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
         nodes=None,
         attr_filter=None,
         read_attrs=None,
+        node_attrs=None,
         targeting_edges=False,
         dangling_attrs=False
     ):
@@ -355,6 +356,16 @@ class MongoDbGraphProvider(SharedGraphProvider):
             logger.debug("first 100 edges read: %s", edges[:100])
 
             if dangling_attrs:
+                projection = {'_id': False}
+                if node_attrs is not None:
+                    projection['id'] = True
+                    if type(self.position_attribute) == list:
+                        for a in self.position_attribute:
+                            projection[a] = True
+                    else:
+                        projection[self.position_attribute] = True
+                    for attr in node_attrs:
+                        projection[attr] = True
 
                 node_ids = set(node_ids)
                 to_fetch = []
@@ -431,6 +442,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 nodes=nodes,
                 attr_filter=edges_filter,
                 read_attrs=edge_attrs,
+                node_attrs=node_attrs,
                 targeting_edges=targeting_edges,
                 dangling_attrs=dangling_attrs)
 

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -332,8 +332,8 @@ class MongoDbGraphProvider(SharedGraphProvider):
                         ]
                     }
                 else:
-                endpoint_query = {self.endpoint_names[0]:
-                                  {'$in': node_ids[i_b:i_e]}}
+                    endpoint_query = {self.endpoint_names[0]:
+                                      {'$in': node_ids[i_b:i_e]}}
                 if attr_filter:
                     query = {'$and': filters + [endpoint_query]}
                 else:
@@ -362,9 +362,9 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 nodes += additional_nodes
 
             else:
-        for edge in edges:
-            edge[u] = np.uint64(edge[u])
-            edge[v] = np.uint64(edge[v])
+                for edge in edges:
+                    edge[u] = np.uint64(edge[u])
+                    edge[v] = np.uint64(edge[v])
 
         finally:
 

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -366,7 +366,8 @@ class MongoDbGraphProvider(SharedGraphProvider):
                     elif edge[v] not in node_ids:
                         to_fetch.append(int(np.int64(edge[v])))
 
-                additional_nodes = list(self.nodes.find({"id": {"$in": to_fetch}}, projection))
+                additional_nodes = list(
+                    self.nodes.find({"id": {"$in": to_fetch}}, projection))
                 nodes += additional_nodes
 
             else:

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -481,10 +481,15 @@ class MongoDbGraphProvider(SharedGraphProvider):
         u, v = self.endpoint_names
         self.edges.create_index(
             [
-                (u, ASCENDING),
+                (u, ASCENDING)
+            ],
+            name='source',
+            unique=True)
+        self.edges.create_index(
+            [
                 (v, ASCENDING)
             ],
-            name='incident',
+            name='target',
             unique=True)
 
     def __check_metadata(self, metadata):

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -529,15 +529,15 @@ class MongoDbGraphProvider(SharedGraphProvider):
         u, v = self.endpoint_names
         self.edges.create_index(
             [
-                (u, ASCENDING)
-            ],
-            name='source',
-            unique=True)
-        self.edges.create_index(
-            [
                 (v, ASCENDING)
             ],
-            name='target',
+            name='target')
+        self.edges.create_index(
+            [
+                (u, ASCENDING),
+                (v, ASCENDING)
+            ],
+            name='incident',
             unique=True)
 
     def __check_metadata(self, metadata):

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -426,34 +426,40 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 nodes=nodes,
                 attr_filter=edges_filter,
                 read_attrs=edge_attrs,
-                node_attrs=node_attrs,
                 edge_inclusion=edge_inclusion)
         if node_inclusion == 'dangling':
-            projection = {'_id': False}
-            if node_attrs is not None:
-                projection['id'] = True
-                if type(self.position_attribute) == list:
-                    for a in self.position_attribute:
-                        projection[a] = True
-                else:
-                    projection[self.position_attribute] = True
-                for attr in node_attrs:
-                    projection[attr] = True
+            try:
+                self.__connect()
+                self.__open_db()
+                self.__open_collections()
+                projection = {'_id': False}
+                if node_attrs is not None:
+                    projection['id'] = True
+                    if type(self.position_attribute) == list:
+                        for a in self.position_attribute:
+                            projection[a] = True
+                    else:
+                        projection[self.position_attribute] = True
+                    for attr in node_attrs:
+                        projection[attr] = True
 
-            node_ids = set([int(np.int64(n['id'])) for n in nodes])
-            u, v = self.endpoint_names
-            to_fetch = []
-            for edge in edges:
-                edge[u] = np.uint64(edge[u])
-                edge[v] = np.uint64(edge[v])
-                if edge[u] not in node_ids:
-                    to_fetch.append(int(np.int64(edge[u])))
-                elif edge[v] not in node_ids:
-                    to_fetch.append(int(np.int64(edge[v])))
+                node_ids = set([int(np.int64(n['id'])) for n in nodes])
+                u, v = self.endpoint_names
+                to_fetch = []
+                for edge in edges:
+                    edge[u] = np.uint64(edge[u])
+                    edge[v] = np.uint64(edge[v])
+                    if edge[u] not in node_ids:
+                        to_fetch.append(int(np.int64(edge[u])))
+                    elif edge[v] not in node_ids:
+                        to_fetch.append(int(np.int64(edge[v])))
 
-            additional_nodes = list(
-                self.nodes.find({"id": {"$in": to_fetch}}, projection))
-            nodes += additional_nodes
+                additional_nodes = list(
+                    self.nodes.find({"id": {"$in": to_fetch}}, projection))
+                nodes += additional_nodes
+
+            finally:
+                self.__disconnect()
 
         u, v = self.endpoint_names
         node_list = [

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -314,7 +314,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
             # limit query to 1M node IDs (otherwise we might exceed the 16MB
             # BSON document size limit)
             length = len(node_ids)
-            query_size = 1000000
+            query_size = 500000
             num_chunks = (length - 1)//query_size + 1
             filters = []
             for attr, value in attr_filter.items():

--- a/daisy/scheduler.py
+++ b/daisy/scheduler.py
@@ -75,6 +75,7 @@ class Scheduler():
 
         self.status_thread = None
         self.periodic_interval = 10
+        self.max_port_tries = 1000
         self.completion_rate = collections.defaultdict(int)
         self.issue_times = {}
 
@@ -232,16 +233,15 @@ class Scheduler():
             t.start()
         self.tcpserver = DaisyTCPServer()
         self.tcpserver.add_handler(self)
-        max_port_tries = 100
-        for i in range(max_port_tries):
+        for i in range(self.max_port_tries):
             try:
                 self.tcpserver.listen(0)  # 0 == random port
                 break
             except OSError:
-                if i == max_port_tries - 1:
+                if i == self.max_port_tries - 1:
                     raise RuntimeError(
                         "Could not find a free port after %d tries " %
-                        max_port_tries)
+                        self.max_port_tries)
                 pass
         self.net_identity = self.tcpserver.get_identity()
 

--- a/daisy/scheduler.py
+++ b/daisy/scheduler.py
@@ -664,7 +664,9 @@ def run_blockwise(
         num_workers=1,
         processes=None,
         max_retries=2,
-        timeout=None):
+        timeout=None,
+        periodic_callback=None,
+        ):
     '''Convenient function to run a single block-wise task.
 
     Args:
@@ -797,6 +799,9 @@ def run_blockwise(
                 max_retries=max_retries,
                 timeout=timeout
                 )
+
+    if periodic_callback is not None:
+        BlockwiseTask._periodic_callback = periodic_callback
 
     return distribute([{'task': BlockwiseTask()}])
 

--- a/daisy/scheduler.py
+++ b/daisy/scheduler.py
@@ -74,7 +74,7 @@ class Scheduler():
         self.started_processes = set()
 
         self.status_thread = None
-        self.periodic_interval = 10
+        self.periodic_interval = 100  # 10s (100x 0.1s)
         self.max_port_tries = 1000
         self.completion_rate = collections.defaultdict(int)
         self.issue_times = {}
@@ -260,8 +260,16 @@ class Scheduler():
         last_time = time.time()
         last_completion_rate = self.completion_rate
         SAMPLING_INTERVAL = 120
+        print_counter = 0
 
         while not self.finished_scheduling:
+
+            if print_counter > 0:
+                time.sleep(0.1)
+                print_counter -= 1
+                continue
+            print_counter = self.periodic_interval
+
             current_time = time.time()
 
             # check workers timeout
@@ -336,8 +344,6 @@ class Scheduler():
                     eta)
 
                 self.tasks[task_id]._periodic_callback()
-
-            time.sleep(self.periodic_interval)
             logger.info("\n")  # separator
 
     def remove_worker_callback(self, worker):

--- a/daisy/tests/test_graph_attribute_functions.py
+++ b/daisy/tests/test_graph_attribute_functions.py
@@ -248,3 +248,141 @@ class TestFilterMongoGraph(unittest.TestCase):
             seen.append(node)
 
         self.assertCountEqual(seen, [2, 42, 23, 57])
+
+    def test_graph_read_dangling_attrs(self):
+        graph_provider = self.get_mongo_graph_provider('w')
+        roi = daisy.Roi((0, 0, 0),
+                        (10, 10, 10))
+        small_roi = daisy.Roi((4, 4, 4), (2, 2, 2))
+        graph = graph_provider[roi]
+
+        graph.add_node(2,
+                       position=(2, 2, 2),
+                       selected=False,
+                       test='test')
+        graph.add_node(42,
+                       position=(1, 1, 1),
+                       selected=False,
+                       test='test2')
+        graph.add_node(23,
+                       position=(5, 5, 5),
+                       selected=True,
+                       test='test2')
+        graph.add_node(57,
+                       position=daisy.Coordinate((7, 7, 7)),
+                       selected=False,
+                       test='test')
+
+        graph.add_edge(42, 23,
+                       selected=False,
+                       a=100,
+                       b=3)
+        graph.add_edge(57, 23,
+                       selected=True,
+                       a=100,
+                       b=2)
+        graph.add_edge(2, 42,
+                       selected=True,
+                       a=101,
+                       b=3)
+
+        graph.write_nodes()
+        graph.write_edges()
+
+        graph_provider = self.get_mongo_graph_provider('r+')
+        limited_graph = graph_provider.get_graph(
+                small_roi,
+                node_attrs=['selected'],
+                edge_attrs=['c'],
+                dangling_attrs=True,
+                targeting_edges=True)
+
+        seen = []
+        for node, data in limited_graph.nodes(data=True):
+            self.assertFalse('test' in data)
+            self.assertTrue('selected' in data)
+            seen.append(node)
+        self.assertCountEqual(seen, [42, 23, 57])
+
+        limited_graph = graph_provider.get_graph(
+                small_roi,
+                node_attrs=['selected'],
+                edge_attrs=['c'],
+                dangling_attrs=False,
+                targeting_edges=True)
+
+        seen = []
+        for node, data in limited_graph.nodes(data=True):
+            self.assertFalse('test' in data)
+            self.assertEqual('selected' in data, node == 23)
+            seen.append(node)
+        self.assertCountEqual(seen, [42, 23, 57])
+
+    def test_graph_read_targeting_edges(self):
+        graph_provider = self.get_mongo_graph_provider('w')
+        roi = daisy.Roi((0, 0, 0),
+                        (10, 10, 10))
+        small_roi = daisy.Roi((4, 4, 4), (2, 2, 2))
+        graph = graph_provider[roi]
+
+        graph.add_node(2,
+                       position=(2, 2, 2),
+                       selected=False,
+                       test='test')
+        graph.add_node(42,
+                       position=(1, 1, 1),
+                       selected=False,
+                       test='test2')
+        graph.add_node(23,
+                       position=(5, 5, 5),
+                       selected=True,
+                       test='test2')
+        graph.add_node(57,
+                       position=daisy.Coordinate((7, 7, 7)),
+                       selected=False,
+                       test='test')
+
+        graph.add_edge(42, 23,
+                       selected=False,
+                       a=100,
+                       b=3)
+        graph.add_edge(57, 23,
+                       selected=True,
+                       a=100,
+                       b=2)
+        graph.add_edge(2, 42,
+                       selected=True,
+                       a=101,
+                       b=3)
+
+        graph.write_nodes()
+        graph.write_edges()
+
+        graph_provider = self.get_mongo_graph_provider('r+')
+        limited_graph = graph_provider.get_graph(
+                small_roi,
+                node_attrs=['selected'],
+                edge_attrs=['c'],
+                dangling_attrs=False,
+                targeting_edges=True)
+
+        seen = []
+        for node, data in limited_graph.nodes(data=True):
+            self.assertFalse('test' in data)
+            self.assertEqual('selected' in data, node == 23)
+            seen.append(node)
+        self.assertCountEqual(seen, [42, 23, 57])
+
+        limited_graph = graph_provider.get_graph(
+                small_roi,
+                node_attrs=['selected'],
+                edge_attrs=['c'],
+                dangling_attrs=False,
+                targeting_edges=False)
+
+        seen = []
+        for node, data in limited_graph.nodes(data=True):
+            self.assertFalse('test' in data)
+            self.assertEqual('selected' in data, node == 23)
+            seen.append(node)
+        self.assertCountEqual(seen, [23])

--- a/daisy/tests/test_graph_attribute_functions.py
+++ b/daisy/tests/test_graph_attribute_functions.py
@@ -294,8 +294,8 @@ class TestFilterMongoGraph(unittest.TestCase):
                 small_roi,
                 node_attrs=['selected'],
                 edge_attrs=['c'],
-                dangling_attrs=True,
-                targeting_edges=True)
+                node_inclusion='dangling',
+                edge_inclusion='either')
 
         seen = []
         for node, data in limited_graph.nodes(data=True):
@@ -308,8 +308,8 @@ class TestFilterMongoGraph(unittest.TestCase):
                 small_roi,
                 node_attrs=['selected'],
                 edge_attrs=['c'],
-                dangling_attrs=False,
-                targeting_edges=True)
+                node_inclusion='strict',
+                edge_inclusion='either')
 
         seen = []
         for node, data in limited_graph.nodes(data=True):
@@ -363,8 +363,8 @@ class TestFilterMongoGraph(unittest.TestCase):
                 small_roi,
                 node_attrs=['selected'],
                 edge_attrs=['c'],
-                dangling_attrs=False,
-                targeting_edges=True)
+                node_inclusion='strict',
+                edge_inclusion='either')
 
         seen = []
         for node, data in limited_graph.nodes(data=True):
@@ -377,8 +377,8 @@ class TestFilterMongoGraph(unittest.TestCase):
                 small_roi,
                 node_attrs=['selected'],
                 edge_attrs=['c'],
-                dangling_attrs=False,
-                targeting_edges=False)
+                node_inclusion='strict',
+                edge_inclusion='u')
 
         seen = []
         for node, data in limited_graph.nodes(data=True):

--- a/daisy/tests/test_klb_adaptor.py
+++ b/daisy/tests/test_klb_adaptor.py
@@ -1,5 +1,5 @@
 import daisy
-from daisy.ext import pyklb
+from daisy.ext import pyklb, NoSuchModule
 import numpy as np
 import unittest
 import json
@@ -30,6 +30,7 @@ class TestArray(unittest.TestCase):
         self.klb_file = None
         self.attrs_file = None
 
+    @unittest.skipIf(isinstance(pyklb, NoSuchModule), "pyklb is not installed")
     def test_load_klb(self):
         self.write_test_klb()
         data = daisy.open_ds(self.klb_file, None)
@@ -41,6 +42,7 @@ class TestArray(unittest.TestCase):
                          daisy.Coordinate((1, 2, 1, 1)))
         self.remove_test_klb()
 
+    @unittest.skipIf(isinstance(pyklb, NoSuchModule), "pyklb is not installed")
     def test_overwrite_attrs(self):
         self.write_test_klb()
         data = daisy.open_ds(self.klb_file,

--- a/daisy/tests/test_klb_adaptor.py
+++ b/daisy/tests/test_klb_adaptor.py
@@ -1,0 +1,55 @@
+import daisy
+import pyklb
+import numpy as np
+import unittest
+import json
+import os
+
+
+class TestArray(unittest.TestCase):
+    def write_test_klb(self):
+        self.klb_file = 'test.klb'
+        data = np.arange(1e3).reshape(1, 1, 10, 10, 10)
+        pyklb.writefull(
+                data,
+                self.klb_file,
+                numthreads=1,
+                pixelspacing_tczyx=[1, 1, 2, 1, 1])
+
+        self.attrs_file = 'attributes.json'
+        attrs = {
+                'resolution': [1, 1, 2, 2],
+                'offset': [0, 100, 10, 0]
+                }
+        with open(self.attrs_file, 'w') as f:
+            json.dump(attrs, f)
+
+    def remove_test_klb(self):
+        os.remove(self.klb_file)
+        os.remove(self.attrs_file)
+        self.klb_file = None
+        self.attrs_file = None
+
+    def test_load_klb(self):
+        self.write_test_klb()
+        data = daisy.open_ds(self.klb_file, None)
+        self.assertEqual(data.roi.get_offset(),
+                         daisy.Coordinate((0, 0, 0, 0)))
+        self.assertEqual(data.roi.get_shape(),
+                         daisy.Coordinate((1, 20, 10, 10)))
+        self.assertEqual(data.voxel_size,
+                         daisy.Coordinate((1, 2, 1, 1)))
+        self.remove_test_klb()
+
+    def test_overwrite_attrs(self):
+        self.write_test_klb()
+        data = daisy.open_ds(self.klb_file,
+                             None,
+                             attr_filename=self.attrs_file)
+        self.assertEqual(data.roi.get_offset(),
+                         daisy.Coordinate((0, 100, 10, 0)))
+        self.assertEqual(data.roi.get_shape(),
+                         daisy.Coordinate((1, 10, 20, 20)))
+        self.assertEqual(data.voxel_size,
+                         daisy.Coordinate((1, 1, 2, 2)))
+        self.remove_test_klb()

--- a/daisy/tests/test_klb_adaptor.py
+++ b/daisy/tests/test_klb_adaptor.py
@@ -1,5 +1,5 @@
 import daisy
-import pyklb
+from daisy.ext import pyklb
 import numpy as np
 import unittest
 import json

--- a/examples/basic_workflow.py
+++ b/examples/basic_workflow.py
@@ -1,0 +1,54 @@
+import daisy
+import argparse
+
+
+def process_function(b):
+    # Normal workflow:
+    #   read data in b.read_roi
+    #   process
+    #   write result to b.write_roi
+    print(b)
+    return 0
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--total_roi_size', '-t', nargs='+',
+                        help="Size of total region to process",
+                        default=[100, 100])
+    parser.add_argument('--block_read_size', '-r', nargs='+',
+                        help="Size of block read region",
+                        default=[20, 20])
+    parser.add_argument('--block_write_size', '-w', nargs='+',
+                        help="Size of block write region",
+                        default=[16, 16])
+    parser.add_argument('--num_workers', '-nw', type=int,
+                        help="Number of processes to spawn",
+                        default=1)
+    parser.add_argument('--read_write_conflict', '-rwc', action='store_true',
+                        help="Flag to not schedule overlapping blocks"
+                        " at the same time. Default is false")
+    args = parser.parse_args()
+
+    ndims = len(args.total_roi_size)
+
+    # define total region of interest (roi)
+    total_roi_start = daisy.Coordinate((0,)*ndims)
+    total_roi_size = daisy.Coordinate(args.total_roi_size)
+    total_roi = daisy.Roi(total_roi_start, total_roi_size)
+
+    # define block read and write rois
+    block_read_size = daisy.Coordinate(args.block_read_size)
+    block_write_size = daisy.Coordinate(args.block_write_size)
+    context = (block_read_size - block_write_size) / 2
+    block_read_roi = daisy.Roi(total_roi_start, block_read_size)
+    block_write_roi = daisy.Roi(context, block_write_size)
+
+    # call run_blockwise
+    daisy.run_blockwise(
+            total_roi,
+            block_read_roi,
+            block_write_roi,
+            process_function=process_function,
+            read_write_conflict=args.read_write_conflict,
+            num_workers=args.num_workers)

--- a/examples/gaussian_smoothing.py
+++ b/examples/gaussian_smoothing.py
@@ -1,0 +1,146 @@
+import daisy
+import argparse
+import numpy as np
+import random
+
+import matplotlib
+import matplotlib.pyplot as plt
+import scipy.ndimage
+
+import logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def create_sample_image(
+        shape=(2000, 2000),
+        num_blobs=100,
+        blob_radius=10,
+        zarr_name="sample_data.zarr",
+        zarr_group="blobs_2d"):
+
+    arr = np.zeros(shape, dtype=np.uint8)
+
+    # put blobs into the array
+    for i in range(num_blobs):
+        point = (random.randint(0, shape[0] - 1),
+                 random.randint(0, shape[1] - 1))
+        for x in range(
+                max(point[0] - blob_radius, 0),
+                min(point[0] + blob_radius, shape[0] - 1)):
+            for y in range(
+                    max(point[1] - blob_radius, 0),
+                    min(point[1] + blob_radius, shape[1] - 1)):
+                arr[x][y] = random.randint(0, 10)
+
+    # prepare dataset
+    total_roi = daisy.Roi((0, 0), shape)
+    dataset = daisy.prepare_ds(
+            zarr_name,
+            zarr_group,
+            total_roi=total_roi,
+            voxel_size=(1, 1),
+            dtype=np.uint8,
+            write_size=(200, 200))
+    dataset[total_roi] = arr
+
+
+def smooth(block, dataset, output, sigma=5):
+    logger.debug("Block: %s" % block)
+
+    # read data in block.read_roi
+    daisy_array = dataset[block.read_roi]
+    data = daisy_array.to_ndarray()
+    logger.debug("Got data of shape %s" % str(data.shape))
+
+    # apply gaussian filter
+    r = scipy.ndimage.gaussian_filter(
+            data, sigma=sigma, mode='constant')
+
+    # write result to output dataset in block.write_roi
+    to_write = daisy.Array(
+            data=r,
+            roi=block.read_roi,
+            voxel_size=dataset.voxel_size)
+    output[block.write_roi] = to_write[block.write_roi]
+    logger.debug("Done")
+    return 0
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--image', '-i', type=str,
+                        help="Path to zarr containing image",
+                        default="sample_data.zarr")
+    parser.add_argument('--group', '-g', type=str,
+                        help="Group or volume name of image within zarr",
+                        default="blobs_2d")
+    parser.add_argument('--output', '-o', type=str,
+                        help="Zarr file to write smoothed image to"
+                        "(will use same group/volume name)",
+                        default="sample_output.zarr")
+    parser.add_argument('--sigma', '-s', type=float,
+                        help="Sigma to use for gaussian filter",
+                        default=2)
+    parser.add_argument('--block_read_size', '-r', nargs='+',
+                        help="Size of block read region",
+                        default=[200, 200])
+    parser.add_argument('--block_write_size', '-w', nargs='+',
+                        help="Size of block write region",
+                        default=[180, 180])
+    parser.add_argument('--num_workers', '-nw', type=int,
+                        help="Number of processes to spawn",
+                        default=1)
+    parser.add_argument('--create_image', action="store_true",
+                        help="Flag to create the sample image zarr")
+    args = parser.parse_args()
+
+    # open dataset
+    dataset = daisy.open_ds(args.image, args.group)
+
+    # write input image to png for visualization
+    # note - you usually would have data to big to do this
+    # for the whole thing
+    plt.imshow(dataset.to_ndarray(), cmap=matplotlib.cm.binary)
+    plt.savefig('image_before_gaussian.png')
+
+    # define total region of interest (roi)
+    total_roi = dataset.roi
+    ndims = len(total_roi.get_offset())
+
+    # define block read and write rois
+    assert len(args.block_read_size) == ndims,\
+        "Read size must have same dimensions as image"
+    assert len(args.block_write_size) == ndims,\
+        "Write size must have same dimensions as image"
+    block_read_size = daisy.Coordinate(args.block_read_size)
+    block_write_size = daisy.Coordinate(args.block_write_size)
+    context = (block_read_size - block_write_size) / 2
+    block_read_roi = daisy.Roi((0,)*ndims, block_read_size)
+    block_write_roi = daisy.Roi(context, block_write_size)
+
+    # prepare output dataset
+    output_roi = total_roi.grow(-context, -context)
+    output_dataset = daisy.prepare_ds(
+            args.output,
+            args.group,
+            total_roi=output_roi,
+            voxel_size=dataset.voxel_size,
+            dtype=dataset.dtype,
+            write_size=block_write_roi.get_shape())
+
+    # call run_blockwise
+    daisy.run_blockwise(
+            total_roi,
+            block_read_roi,
+            block_write_roi,
+            process_function=lambda b: smooth(
+                b, dataset, output_dataset, sigma=args.sigma),
+            read_write_conflict=False,
+            num_workers=args.num_workers)
+
+    # write output image to png for visualization
+    # note - you usually would have data to big to do this
+    # for the whole thing
+    plt.imshow(output_dataset.to_ndarray(), cmap=matplotlib.cm.binary)
+    plt.savefig('image_after_gaussian.png')


### PR DESCRIPTION
Adds two toggles for read_edges and get_graph:
targetting_edges: also return edges that have their target node in the queried roi.
dangling_attrs: include dangling nodes so that their attributes are included in the graph.

Edge index needed to change to support this query. Instead of having a compound index on (u, v), we now create 2 indexes, one for u and one for v. This allows for equally efficient ( I think ) querying of u, more efficient querying of v ( compound index leads to a simple collection scan ), but less efficient ( I think ) querying of u, v pairs.