### PR TITLE
Make Coordinate add and mul operations commutative

### DIFF
--- a/daisy/array.py
+++ b/daisy/array.py
@@ -98,7 +98,7 @@ class Array(Freezable):
         '''
 
         view_shape = (self.roi/self.voxel_size).get_shape()
-        return self.data.shape[:self.n_channel_dims] + view_shape
+        return self.data.shape[:self.n_channel_dims] + tuple(view_shape)
 
     @property
     def dtype(self):
@@ -237,7 +237,7 @@ class Array(Freezable):
 
         shape = (roi/self.voxel_size).get_shape()
         data = np.zeros(
-            self.data.shape[:self.n_channel_dims] + shape,
+            self.data.shape[:self.n_channel_dims] + tuple(shape),
             dtype=self.data.dtype)
         if fill_value != 0:
             data[:] = fill_value
@@ -297,5 +297,5 @@ class Array(Freezable):
 
         index = (coordinate - self.data_roi.get_begin())/self.voxel_size
         if self.n_channel_dims > 0:
-            index = (Ellipsis,) + index
+            index = (Ellipsis,) + tuple(index)
         return index

--- a/daisy/coordinate.py
+++ b/daisy/coordinate.py
@@ -60,6 +60,10 @@ class Coordinate(tuple):
             else None
             for a, b in zip(self, other))
 
+    def __radd__(self, other):
+
+        return self.__add__(other)
+
     def __sub__(self, other):
 
         if not isinstance(other, tuple):
@@ -100,6 +104,10 @@ class Coordinate(tuple):
             raise TypeError(
                 "multiplication of Coordinate with type %s not supported" %
                 type(other))
+
+    def __rmul__(self, other):
+
+        return self.__mul__(other)
 
     def __div__(self, other):  # pragma: py3 no cover
 


### PR DESCRIPTION
Mimics the changes in this [gunpowder PR](https://github.com/funkey/gunpowder/pull/130).

Coordindates are fixed to be integers.
Therefore, addition and multiplication of Coordinates with other numbers/tuples of numbers should
be commutative to correspond to our intuition.