### PR TITLE
Rstrip filename in open_ds

### DIFF
--- a/daisy/datasets.py
+++ b/daisy/datasets.py
@@ -93,6 +93,8 @@ def open_ds(filename, ds_name, mode='r', attr_filename=None):
         A :class:`daisy.Array` pointing to the dataset.
     '''
 
+    filename = filename.rstrip('/')
+
     if filename.endswith('.zarr'):
 
         logger.debug("opening zarr dataset %s in %s", ds_name, filename)


### PR DESCRIPTION
When using autocomplete to specify zarr or n5 filenames in `open_ds`,
a trailing slash is often added, which would break this function.
Trailing slashes are rstripped now.