### PR TITLE
Dangling attributes rebased

### DIFF
--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -259,7 +259,15 @@ class MongoDbGraphProvider(SharedGraphProvider):
 
         return False
 
-    def read_edges(self, roi, nodes=None, attr_filter=None, read_attrs=None, targeting_edges=False, dangling_attrs=False):
+    def read_edges(
+        self,
+        roi,
+        nodes=None,
+        attr_filter=None,
+        read_attrs=None,
+        targeting_edges=False,
+        dangling_attrs=False
+    ):
         '''Returns a list of edges within roi.
         Arguments:
 
@@ -355,7 +363,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
             logger.debug("first 100 edges read: %s", edges[:100])
 
             if dangling_attrs:
-            
+
                 node_ids = set(node_ids)
                 to_fetch = []
                 for edge in edges:

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -340,10 +340,8 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 elif edge_inclusion == 'v':
                     endpoint_query = {v: {'$in': node_ids[i_b:i_e]}}
                 elif edge_inclusion == 'both':
-                    endpoint_query = {
-                        u: {"$in": node_ids[i_b:i_e]},
-                        v: {"$in": node_ids[i_b:i_e]}
-                    }
+                    raise NotImplementedError(
+                        "Both option for read edges not implemented")
                 elif edge_inclusion == 'either':
                     endpoint_query = {
                         "$or": [

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -340,8 +340,10 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 elif edge_inclusion == 'v':
                     endpoint_query = {v: {'$in': node_ids[i_b:i_e]}}
                 elif edge_inclusion == 'both':
-                    raise NotImplementedError(
-                        "Both option for read edges not implemented")
+                    endpoint_query = {
+                        u: {"$in": node_ids[i_b:i_e]},
+                        v: {"$in": node_ids[i_b:i_e]}
+                    }
                 elif edge_inclusion == 'either':
                     endpoint_query = {
                         "$or": [

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -265,6 +265,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
         nodes=None,
         attr_filter=None,
         read_attrs=None,
+        node_attrs=None,
         targeting_edges=False,
         dangling_attrs=False
     ):
@@ -363,6 +364,16 @@ class MongoDbGraphProvider(SharedGraphProvider):
             logger.debug("first 100 edges read: %s", edges[:100])
 
             if dangling_attrs:
+                projection = {'_id': False}
+                if node_attrs is not None:
+                    projection['id'] = True
+                    if type(self.position_attribute) == list:
+                        for a in self.position_attribute:
+                            projection[a] = True
+                    else:
+                        projection[self.position_attribute] = True
+                    for attr in node_attrs:
+                        projection[attr] = True
 
                 node_ids = set(node_ids)
                 to_fetch = []
@@ -440,6 +451,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 nodes=nodes,
                 attr_filter=edges_filter,
                 read_attrs=edge_attrs,
+                node_attrs=node_attrs,
                 targeting_edges=targeting_edges,
                 dangling_attrs=dangling_attrs)
 

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -265,9 +265,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
         nodes=None,
         attr_filter=None,
         read_attrs=None,
-        node_attrs=None,
-        targeting_edges=False,
-        dangling_attrs=False
+        edge_inclusion='u'
     ):
         '''Returns a list of edges within roi.
         Arguments:
@@ -291,17 +289,13 @@ class MongoDbGraphProvider(SharedGraphProvider):
 
                 Attributes to return. Others will be ignored
 
-            targeting_edges (``bool``):
+            edge_inclusion ('u', 'v', 'either', or 'both'):
 
-                Whether to also return edges with targets in this node list.
+                Include edges with only 'u' node inside roi,
+                only 'v' node inside roi, both ends inside roi,
+                or either end inside roi. Default is 'u'.
 
-            dangling_attrs (``bool``):
-
-                Whether to include attributes of dangling nodes. If True,
-                the dangling nodes will be queried and appended to nodes.
-                dangling_attrs cannot be true of nodes is None.
         '''
-        dangling_attrs = dangling_attrs and nodes is not None
 
         if nodes is None:
             nodes = self.read_nodes(roi)
@@ -341,16 +335,20 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 i_b = i*query_size
                 i_e = min((i + 1)*query_size, len(node_ids))
                 assert i_b < len(node_ids)
-                if targeting_edges:
+                if edge_inclusion == 'u':
+                    endpoint_query = {u: {'$in': node_ids[i_b:i_e]}}
+                elif edge_inclusion == 'v':
+                    endpoint_query = {v: {'$in': node_ids[i_b:i_e]}}
+                elif edge_inclusion == 'both':
+                    raise NotImplementedError(
+                        "Both option for read edges not implemented")
+                elif edge_inclusion == 'either':
                     endpoint_query = {
                         "$or": [
                             {u: {"$in": node_ids[i_b:i_e]}},
                             {v: {"$in": node_ids[i_b:i_e]}},
                         ]
                     }
-                else:
-                    endpoint_query = {self.endpoint_names[0]:
-                                      {'$in': node_ids[i_b:i_e]}}
                 if attr_filter:
                     query = {'$and': filters + [endpoint_query]}
                 else:
@@ -363,36 +361,9 @@ class MongoDbGraphProvider(SharedGraphProvider):
             logger.debug("found %d edges", len(edges))
             logger.debug("first 100 edges read: %s", edges[:100])
 
-            if dangling_attrs:
-                projection = {'_id': False}
-                if node_attrs is not None:
-                    projection['id'] = True
-                    if type(self.position_attribute) == list:
-                        for a in self.position_attribute:
-                            projection[a] = True
-                    else:
-                        projection[self.position_attribute] = True
-                    for attr in node_attrs:
-                        projection[attr] = True
-
-                node_ids = set(node_ids)
-                to_fetch = []
-                for edge in edges:
-                    edge[u] = np.uint64(edge[u])
-                    edge[v] = np.uint64(edge[v])
-                    if edge[u] not in node_ids:
-                        to_fetch.append(int(np.int64(edge[u])))
-                    elif edge[v] not in node_ids:
-                        to_fetch.append(int(np.int64(edge[v])))
-
-                additional_nodes = list(
-                    self.nodes.find({"id": {"$in": to_fetch}}, projection))
-                nodes += additional_nodes
-
-            else:
-                for edge in edges:
-                    edge[u] = np.uint64(edge[u])
-                    edge[v] = np.uint64(edge[v])
+            for edge in edges:
+                edge[u] = np.uint64(edge[u])
+                edge[v] = np.uint64(edge[v])
 
         except Exception as e:
 
@@ -412,8 +383,8 @@ class MongoDbGraphProvider(SharedGraphProvider):
             edges_filter=None,
             node_attrs=None,
             edge_attrs=None,
-            targeting_edges=False,
-            dangling_attrs=False):
+            node_inclusion='strict',
+            edge_inclusion='u'):
         ''' Return a graph within roi, optionally filtering by
         node and edge attributes.
 
@@ -441,6 +412,19 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 attributes will be ignored, but source and target
                 will always be included. If None (default), return all attrs.
 
+            node_inclusion ('strict' or 'dangling'):
+
+                If 'strict,' only include dummy nodes (aka ids) for nodes
+                outside the roi, that are included by being the other end
+                of an edge. If 'dangling,' include attributes for the dangling
+                nodes outside the roi. Default is 'strict'.
+
+            edge_inclusion ('u', 'v', 'either', or 'both'):
+
+                Include edges with only 'u' node inside roi,
+                only 'v' node inside roi, both ends inside roi,
+                or either end inside roi. Default is 'u'.
+
         '''
         nodes = self.read_nodes(
                 roi,
@@ -452,8 +436,33 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 attr_filter=edges_filter,
                 read_attrs=edge_attrs,
                 node_attrs=node_attrs,
-                targeting_edges=targeting_edges,
-                dangling_attrs=dangling_attrs)
+                edge_inclusion=edge_inclusion)
+        if node_inclusion == 'dangling':
+            projection = {'_id': False}
+            if node_attrs is not None:
+                projection['id'] = True
+                if type(self.position_attribute) == list:
+                    for a in self.position_attribute:
+                        projection[a] = True
+                else:
+                    projection[self.position_attribute] = True
+                for attr in node_attrs:
+                    projection[attr] = True
+
+            node_ids = set([int(np.int64(n['id'])) for n in nodes])
+            u, v = self.endpoint_names
+            to_fetch = []
+            for edge in edges:
+                edge[u] = np.uint64(edge[u])
+                edge[v] = np.uint64(edge[v])
+                if edge[u] not in node_ids:
+                    to_fetch.append(int(np.int64(edge[u])))
+                elif edge[v] not in node_ids:
+                    to_fetch.append(int(np.int64(edge[v])))
+
+            additional_nodes = list(
+                self.nodes.find({"id": {"$in": to_fetch}}, projection))
+            nodes += additional_nodes
 
         u, v = self.endpoint_names
         node_list = [

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -542,15 +542,15 @@ class MongoDbGraphProvider(SharedGraphProvider):
         u, v = self.endpoint_names
         self.edges.create_index(
             [
-                (u, ASCENDING)
-            ],
-            name='source',
-            unique=True)
-        self.edges.create_index(
-            [
                 (v, ASCENDING)
             ],
-            name='target',
+            name='target')
+        self.edges.create_index(
+            [
+                (u, ASCENDING),
+                (v, ASCENDING)
+            ],
+            name='incident',
             unique=True)
 
     def __check_metadata(self, metadata):

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -374,7 +374,8 @@ class MongoDbGraphProvider(SharedGraphProvider):
                     elif edge[v] not in node_ids:
                         to_fetch.append(int(np.int64(edge[v])))
 
-                additional_nodes = list(self.nodes.find({"id": {"$in": to_fetch}}, projection))
+                additional_nodes = list(
+                    self.nodes.find({"id": {"$in": to_fetch}}, projection))
                 nodes += additional_nodes
 
             else:

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -322,7 +322,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
             # limit query to 1M node IDs (otherwise we might exceed the 16MB
             # BSON document size limit)
             length = len(node_ids)
-            query_size = 1000000
+            query_size = 500000
             num_chunks = (length - 1)//query_size + 1
             filters = []
             for attr, value in attr_filter.items():

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -340,8 +340,8 @@ class MongoDbGraphProvider(SharedGraphProvider):
                         ]
                     }
                 else:
-                endpoint_query = {self.endpoint_names[0]:
-                                  {'$in': node_ids[i_b:i_e]}}
+                    endpoint_query = {self.endpoint_names[0]:
+                                      {'$in': node_ids[i_b:i_e]}}
                 if attr_filter:
                     query = {'$and': filters + [endpoint_query]}
                 else:
@@ -369,9 +369,10 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 additional_nodes = list(self.nodes.find({"id": {"$in": to_fetch}}, projection))
                 nodes += additional_nodes
 
-            for edge in edges:
-                edge[u] = np.uint64(edge[u])
-                edge[v] = np.uint64(edge[v])
+            else:
+                for edge in edges:
+                    edge[u] = np.uint64(edge[u])
+                    edge[v] = np.uint64(edge[v])
 
         except Exception as e:
 

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -494,10 +494,15 @@ class MongoDbGraphProvider(SharedGraphProvider):
         u, v = self.endpoint_names
         self.edges.create_index(
             [
-                (u, ASCENDING),
+                (u, ASCENDING)
+            ],
+            name='source',
+            unique=True)
+        self.edges.create_index(
+            [
                 (v, ASCENDING)
             ],
-            name='incident',
+            name='target',
             unique=True)
 
     def __check_metadata(self, metadata):

--- a/daisy/persistence/mongodb_graph_provider.py
+++ b/daisy/persistence/mongodb_graph_provider.py
@@ -259,7 +259,7 @@ class MongoDbGraphProvider(SharedGraphProvider):
 
         return False
 
-    def read_edges(self, roi, nodes=None, attr_filter=None, read_attrs=None):
+    def read_edges(self, roi, nodes=None, attr_filter=None, read_attrs=None, targeting_edges=False, dangling_attrs=False):
         '''Returns a list of edges within roi.
         Arguments:
 
@@ -281,7 +281,18 @@ class MongoDbGraphProvider(SharedGraphProvider):
             read_attrs (``list`` of ``string``):
 
                 Attributes to return. Others will be ignored
+
+            targeting_edges (``bool``):
+
+                Whether to also return edges with targets in this node list.
+
+            dangling_attrs (``bool``):
+
+                Whether to include attributes of dangling nodes. If True,
+                the dangling nodes will be queried and appended to nodes.
+                dangling_attrs cannot be true of nodes is None.
         '''
+        dangling_attrs = dangling_attrs and nodes is not None
 
         if nodes is None:
             nodes = self.read_nodes(roi)
@@ -321,6 +332,14 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 i_b = i*query_size
                 i_e = min((i + 1)*query_size, len(node_ids))
                 assert i_b < len(node_ids)
+                if targeting_edges:
+                    endpoint_query = {
+                        "$or": [
+                            {u: {"$in": node_ids[i_b:i_e]}},
+                            {v: {"$in": node_ids[i_b:i_e]}},
+                        ]
+                    }
+                else:
                 endpoint_query = {self.endpoint_names[0]:
                                   {'$in': node_ids[i_b:i_e]}}
                 if attr_filter:
@@ -335,14 +354,29 @@ class MongoDbGraphProvider(SharedGraphProvider):
             logger.debug("found %d edges", len(edges))
             logger.debug("first 100 edges read: %s", edges[:100])
 
+            if dangling_attrs:
+            
+                node_ids = set(node_ids)
+                to_fetch = []
+                for edge in edges:
+                    edge[u] = np.uint64(edge[u])
+                    edge[v] = np.uint64(edge[v])
+                    if edge[u] not in node_ids:
+                        to_fetch.append(int(np.int64(edge[u])))
+                    elif edge[v] not in node_ids:
+                        to_fetch.append(int(np.int64(edge[v])))
+
+                additional_nodes = list(self.nodes.find({"id": {"$in": to_fetch}}, projection))
+                nodes += additional_nodes
+
+            for edge in edges:
+                edge[u] = np.uint64(edge[u])
+                edge[v] = np.uint64(edge[v])
+
         except Exception as e:
 
             self.__disconnect()
             raise e
-
-        for edge in edges:
-            edge[u] = np.uint64(edge[u])
-            edge[v] = np.uint64(edge[v])
 
         return edges
 
@@ -356,7 +390,9 @@ class MongoDbGraphProvider(SharedGraphProvider):
             nodes_filter=None,
             edges_filter=None,
             node_attrs=None,
-            edge_attrs=None):
+            edge_attrs=None,
+            targeting_edges=False,
+            dangling_attrs=False):
         ''' Return a graph within roi, optionally filtering by
         node and edge attributes.
 
@@ -393,7 +429,10 @@ class MongoDbGraphProvider(SharedGraphProvider):
                 roi,
                 nodes=nodes,
                 attr_filter=edges_filter,
-                read_attrs=edge_attrs)
+                read_attrs=edge_attrs,
+                targeting_edges=targeting_edges,
+                dangling_attrs=dangling_attrs)
+
         u, v = self.endpoint_names
         node_list = [
                 (n['id'], self.__remove_keys(n, ['id']))

--- a/daisy/tests/test_graph_attribute_functions.py
+++ b/daisy/tests/test_graph_attribute_functions.py
@@ -248,3 +248,141 @@ class TestFilterMongoGraph(unittest.TestCase):
             seen.append(node)
 
         self.assertCountEqual(seen, [2, 42, 23, 57])
+
+    def test_graph_read_dangling_attrs(self):
+        graph_provider = self.get_mongo_graph_provider('w')
+        roi = daisy.Roi((0, 0, 0),
+                        (10, 10, 10))
+        small_roi = daisy.Roi((4, 4, 4), (2, 2, 2))
+        graph = graph_provider[roi]
+
+        graph.add_node(2,
+                       position=(2, 2, 2),
+                       selected=False,
+                       test='test')
+        graph.add_node(42,
+                       position=(1, 1, 1),
+                       selected=False,
+                       test='test2')
+        graph.add_node(23,
+                       position=(5, 5, 5),
+                       selected=True,
+                       test='test2')
+        graph.add_node(57,
+                       position=daisy.Coordinate((7, 7, 7)),
+                       selected=False,
+                       test='test')
+
+        graph.add_edge(42, 23,
+                       selected=False,
+                       a=100,
+                       b=3)
+        graph.add_edge(57, 23,
+                       selected=True,
+                       a=100,
+                       b=2)
+        graph.add_edge(2, 42,
+                       selected=True,
+                       a=101,
+                       b=3)
+
+        graph.write_nodes()
+        graph.write_edges()
+
+        graph_provider = self.get_mongo_graph_provider('r+')
+        limited_graph = graph_provider.get_graph(
+                small_roi,
+                node_attrs=['selected'],
+                edge_attrs=['c'],
+                dangling_attrs=True,
+                targeting_edges=True)
+
+        seen = []
+        for node, data in limited_graph.nodes(data=True):
+            self.assertFalse('test' in data)
+            self.assertTrue('selected' in data)
+            seen.append(node)
+        self.assertCountEqual(seen, [42, 23, 57])
+
+        limited_graph = graph_provider.get_graph(
+                small_roi,
+                node_attrs=['selected'],
+                edge_attrs=['c'],
+                dangling_attrs=False,
+                targeting_edges=True)
+
+        seen = []
+        for node, data in limited_graph.nodes(data=True):
+            self.assertFalse('test' in data)
+            self.assertEqual('selected' in data, node == 23)
+            seen.append(node)
+        self.assertCountEqual(seen, [42, 23, 57])
+
+    def test_graph_read_targeting_edges(self):
+        graph_provider = self.get_mongo_graph_provider('w')
+        roi = daisy.Roi((0, 0, 0),
+                        (10, 10, 10))
+        small_roi = daisy.Roi((4, 4, 4), (2, 2, 2))
+        graph = graph_provider[roi]
+
+        graph.add_node(2,
+                       position=(2, 2, 2),
+                       selected=False,
+                       test='test')
+        graph.add_node(42,
+                       position=(1, 1, 1),
+                       selected=False,
+                       test='test2')
+        graph.add_node(23,
+                       position=(5, 5, 5),
+                       selected=True,
+                       test='test2')
+        graph.add_node(57,
+                       position=daisy.Coordinate((7, 7, 7)),
+                       selected=False,
+                       test='test')
+
+        graph.add_edge(42, 23,
+                       selected=False,
+                       a=100,
+                       b=3)
+        graph.add_edge(57, 23,
+                       selected=True,
+                       a=100,
+                       b=2)
+        graph.add_edge(2, 42,
+                       selected=True,
+                       a=101,
+                       b=3)
+
+        graph.write_nodes()
+        graph.write_edges()
+
+        graph_provider = self.get_mongo_graph_provider('r+')
+        limited_graph = graph_provider.get_graph(
+                small_roi,
+                node_attrs=['selected'],
+                edge_attrs=['c'],
+                dangling_attrs=False,
+                targeting_edges=True)
+
+        seen = []
+        for node, data in limited_graph.nodes(data=True):
+            self.assertFalse('test' in data)
+            self.assertEqual('selected' in data, node == 23)
+            seen.append(node)
+        self.assertCountEqual(seen, [42, 23, 57])
+
+        limited_graph = graph_provider.get_graph(
+                small_roi,
+                node_attrs=['selected'],
+                edge_attrs=['c'],
+                dangling_attrs=False,
+                targeting_edges=False)
+
+        seen = []
+        for node, data in limited_graph.nodes(data=True):
+            self.assertFalse('test' in data)
+            self.assertEqual('selected' in data, node == 23)
+            seen.append(node)
+        self.assertCountEqual(seen, [23])

--- a/daisy/tests/test_graph_attribute_functions.py
+++ b/daisy/tests/test_graph_attribute_functions.py
@@ -318,6 +318,20 @@ class TestFilterMongoGraph(unittest.TestCase):
             seen.append(node)
         self.assertCountEqual(seen, [42, 23, 57])
 
+        limited_graph = graph_provider.get_graph(
+                small_roi,
+                node_attrs=['selected'],
+                edge_attrs=['c'],
+                node_inclusion='dangling',
+                edge_inclusion='both')
+
+        seen = []
+        for node, data in limited_graph.nodes(data=True):
+            self.assertFalse('test' in data)
+            self.assertTrue('selected' in data)
+            seen.append(node)
+        self.assertCountEqual(seen, [23])
+
     def test_graph_read_targeting_edges(self):
         graph_provider = self.get_mongo_graph_provider('w')
         roi = daisy.Roi((0, 0, 0),

--- a/daisy/tests/test_graph_attribute_functions.py
+++ b/daisy/tests/test_graph_attribute_functions.py
@@ -318,20 +318,6 @@ class TestFilterMongoGraph(unittest.TestCase):
             seen.append(node)
         self.assertCountEqual(seen, [42, 23, 57])
 
-        limited_graph = graph_provider.get_graph(
-                small_roi,
-                node_attrs=['selected'],
-                edge_attrs=['c'],
-                node_inclusion='dangling',
-                edge_inclusion='both')
-
-        seen = []
-        for node, data in limited_graph.nodes(data=True):
-            self.assertFalse('test' in data)
-            self.assertTrue('selected' in data)
-            seen.append(node)
-        self.assertCountEqual(seen, [23])
-
     def test_graph_read_targeting_edges(self):
         graph_provider = self.get_mongo_graph_provider('w')
         roi = daisy.Roi((0, 0, 0),

--- a/daisy/tests/test_graph_attribute_functions.py
+++ b/daisy/tests/test_graph_attribute_functions.py
@@ -294,8 +294,8 @@ class TestFilterMongoGraph(unittest.TestCase):
                 small_roi,
                 node_attrs=['selected'],
                 edge_attrs=['c'],
-                dangling_attrs=True,
-                targeting_edges=True)
+                node_inclusion='dangling',
+                edge_inclusion='either')
 
         seen = []
         for node, data in limited_graph.nodes(data=True):
@@ -308,8 +308,8 @@ class TestFilterMongoGraph(unittest.TestCase):
                 small_roi,
                 node_attrs=['selected'],
                 edge_attrs=['c'],
-                dangling_attrs=False,
-                targeting_edges=True)
+                node_inclusion='strict',
+                edge_inclusion='either')
 
         seen = []
         for node, data in limited_graph.nodes(data=True):
@@ -363,8 +363,8 @@ class TestFilterMongoGraph(unittest.TestCase):
                 small_roi,
                 node_attrs=['selected'],
                 edge_attrs=['c'],
-                dangling_attrs=False,
-                targeting_edges=True)
+                node_inclusion='strict',
+                edge_inclusion='either')
 
         seen = []
         for node, data in limited_graph.nodes(data=True):
@@ -377,8 +377,8 @@ class TestFilterMongoGraph(unittest.TestCase):
                 small_roi,
                 node_attrs=['selected'],
                 edge_attrs=['c'],
-                dangling_attrs=False,
-                targeting_edges=False)
+                node_inclusion='strict',
+                edge_inclusion='u')
 
         seen = []
         for node, data in limited_graph.nodes(data=True):


### PR DESCRIPTION
Adds two toggles for read_edges and get_graph:
targetting_edges: also return edges that have their target node in the queried roi.
dangling_attrs: include dangling nodes so that their attributes are included in the graph.

Edge index needed to change to support this query. Instead of having a compound index on (u, v), we now create 2 indexes, one for u and one for v. This allows for equally efficient ( I think ) querying of u, more efficient querying of v ( compound index leads to a simple collection scan ), but less efficient ( I think ) querying of u, v pairs.