### PR TITLE
Allow a singleton dimension in prepare_ds

### DIFF
--- a/daisy/datasets.py
+++ b/daisy/datasets.py
@@ -179,7 +179,7 @@ def prepare_ds(
         dtype,
         write_roi=None,
         write_size=None,
-        num_channels=1,
+        num_channels=None,
         compressor='default',
         delete=False,
         force_exact_write_size=False):
@@ -280,7 +280,7 @@ def prepare_ds(
 
     shape = total_roi.shape/voxel_size
 
-    if num_channels > 1:
+    if num_channels is not None:
 
         shape = (num_channels,) + shape
 
@@ -317,7 +317,7 @@ def prepare_ds(
             ds.attrs['resolution'] = voxel_size[::-1]
             ds.attrs['offset'] = total_roi.begin[::-1]
 
-        if num_channels > 1:
+        if num_channels is not None:
             chunk_shape = chunk_shape/voxel_size_with_channels
         else:
             chunk_shape = chunk_shape/voxel_size

--- a/daisy/datasets.py
+++ b/daisy/datasets.py
@@ -317,10 +317,11 @@ def prepare_ds(
             ds.attrs['resolution'] = voxel_size[::-1]
             ds.attrs['offset'] = total_roi.begin[::-1]
 
-        if num_channels is not None:
-            chunk_shape = chunk_shape/voxel_size_with_channels
-        else:
-            chunk_shape = chunk_shape/voxel_size
+        if chunk_shape is not None:
+            if num_channels is not None:
+                chunk_shape = chunk_shape/voxel_size_with_channels
+            else:
+                chunk_shape = chunk_shape/voxel_size
         return Array(
             ds,
             total_roi,


### PR DESCRIPTION
Default is still to not provide a singleton dimension, but if I ask for 1 channel sometimes I want a channel dim of size 1.
I don't always want to handle this case specially.