### PR TITLE
run upstream tasks blockwise

### DIFF
--- a/daisy/convenience.py
+++ b/daisy/convenience.py
@@ -17,7 +17,16 @@ def run_blockwise(tasks):
                 `True` if all blocks in the given `tasks` were successfully
                 run, else `False`
     '''
+    task_ids = set()
+    all_tasks = []
+    while len(tasks) > 0:
+        task, tasks = tasks[0], tasks[1:]
+        if task.task_id not in task_ids:
+            task_ids.add(task.task_id)
+            all_tasks.append(task)
+        tasks.extend(task.upstream_tasks)
 
+    tasks = all_tasks
     stop_event = Event()
 
     IOLooper.clear()


### PR DESCRIPTION
If I have a task with upstream task dependencies and I run it blockwise, I expect it to complete the upstream dependencies and then the task I specified. Current behavior is to hang forever.

Maybe better to fix this in the server.run_blockwise rather than the convenience wrapper?

minimal example:
```python
import daisy


def process_block(block):
    print("Processing block %s" % block)

upstream_task = daisy.Task(
    "upstream_task",
    total_roi=daisy.Roi((0,), (100,)),
    read_roi=daisy.Roi((0,), (10,)),
    write_roi=daisy.Roi((1,), (8,)),
    process_function=lambda b: process_block(b),
)

task = daisy.Task(
    "final_task",
    total_roi=daisy.Roi((0,), (100,)),
    read_roi=daisy.Roi((0,), (10,)),
    write_roi=daisy.Roi((1,), (8,)),
    process_function=lambda b: process_block(b),
    upstream_tasks=[upstream_task]
)

daisy.run_blockwise([task])
```