### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Daisy is a library framework that facilitates distributed processing of big nD datasets across clusters of computers.
 It combines the best of MapReduce/Hadoop (the ability to map a process function across elements) and Luigi (the ability to chain dependent tasks together) together in one lightweight and efficient package with a focus on processing nD datasets.
 
-Daisy documentations are at https://daisy-doc.readthedocs.io/
+Daisy documentations are at https://daisy-docs.readthedocs.io/
 
 
 ## Overview


### PR DESCRIPTION
Added an "s" to the documentation link!

Currently the readthedocs link points to the wrong spot! Just adding an s to `daisy-doc` gets you to the right place.