### PR TITLE
remove funlib library commit hash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
             "networkx",
             "pymongo<4",
             "tqdm",
-            "funlib.math @ git+https://github.com/funkelab/funlib.math@0c623f71c083d33184cac40ef7b1b995216be8ef",
-            "funlib.geometry @ git+https://github.com/funkelab/funlib.geometry@cf30e4d74eb860e46de40533c4f8278dc25147b1",
+            "funlib.math @ git+https://github.com/funkelab/funlib.math",
+            "funlib.geometry @ git+https://github.com/funkelab/funlib.geometry",
         ]
 )


### PR DESCRIPTION
Using the commit hash makes it difficult to write libraries that depend on daisy and funlib packages without specifying the exact same hash.

For example including "funlib.math @ git+https://github.com/funkelab/funlib.math" and "daisy" in a new package setup.py `instal_requires` results in the following error message:
```
The conflict is caused by:
    {your package} depends on funlib-math 0.1 (from git+https://github.com/funkelab/funlib.math)
    daisy 1.0 depends on funlib-math 0.1 (from git+https://github.com/funkelab/funlib.math@0c623f71c083d33184cac40ef7b1b995216be8ef)
```