### PR TITLE
enable reading zarr files with zip storage

### DIFF
--- a/daisy/datasets.py
+++ b/daisy/datasets.py
@@ -98,7 +98,10 @@ def open_ds(filename, ds_name, mode='r', attr_filename=None):
         A :class:`daisy.Array` pointing to the dataset.
     '''
 
-    if filename.endswith('.zarr'):
+    if filename.endswith('.zarr') or filename.endswith('.zip'):
+
+        assert not filename.endswith('.zip') or mode == 'r', (
+            "Only reading supported for zarr ZipStore")
 
         logger.debug("opening zarr dataset %s in %s", ds_name, filename)
         try:


### PR DESCRIPTION
zarr supports storing the data in a zip file
https://zarr.readthedocs.io/en/stable/api/storage.html#zarr.storage.ZipStore

To keep it simple, only reading (if zip storage is used the file object has to be closed explicitly for the data to be written).