### PR TITLE
Work on mac

### DIFF
--- a/daisy/worker.py
+++ b/daisy/worker.py
@@ -4,6 +4,7 @@ import logging
 import multiprocessing
 import os
 import queue
+import dill
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,14 @@ class Worker:
         self.process = None
 
         self.start()
+
+    @property
+    def spawn_function(self):
+        return dill.loads(self._spawn_function)
+    
+    @spawn_function.setter
+    def spawn_function(self, value):
+        self._spawn_function = dill.dumps(value)
 
     def start(self):
         """Start this worker. Note that workers are automatically started when

--- a/daisy/worker.py
+++ b/daisy/worker.py
@@ -54,7 +54,7 @@ class Worker:
     @property
     def spawn_function(self):
         return dill.loads(self._spawn_function)
-    
+
     @spawn_function.setter
     def spawn_function(self, value):
         self._spawn_function = dill.dumps(value)

--- a/daisy/worker.py
+++ b/daisy/worker.py
@@ -27,6 +27,7 @@ class Worker:
     """
 
     __next_id = multiprocessing.Value("L")
+    _spawn_function = None
 
     @staticmethod
     def get_next_id():
@@ -56,7 +57,7 @@ class Worker:
         if self.process is not None:
             return
 
-        self.process = multiprocessing.Process(target=lambda: self.__spawn_wrapper())
+        self.process = multiprocessing.Process(target=self._spawn_wrapper)
         self.process.start()
 
     def stop(self):
@@ -74,7 +75,7 @@ class Worker:
         logger.debug("%s terminated", self)
         self.process = None
 
-    def __spawn_wrapper(self):
+    def _spawn_wrapper(self):
         """Thin wrapper around the user-specified spawn function to set
         environment variables, redirect output, and to capture exceptions."""
 

--- a/daisy/worker_pool.py
+++ b/daisy/worker_pool.py
@@ -67,12 +67,12 @@ class WorkerPool:
             logger.debug("current number of workers: %d", len(self.workers))
 
             if diff > 0:
-                self.__start_workers(diff)
+                self._start_workers(diff)
             elif diff < 0:
-                self.__stop_workers(-diff)
+                self._stop_workers(-diff)
 
     def inc_num_workers(self, num_workers):
-        self.__start_workers(num_workers)
+        self._start_workers(num_workers)
 
     def stop(self, worker_id=None):
         """Stop all current workers in this pool (``worker_id == None``) or a
@@ -104,7 +104,7 @@ class WorkerPool:
         except queue.Empty:
             pass
 
-    def __start_workers(self, n):
+    def _start_workers(self, n):
 
         logger.debug("starting %d new workers", n)
         new_workers = [
@@ -113,7 +113,7 @@ class WorkerPool:
         ]
         self.workers.update({worker.worker_id: worker for worker in new_workers})
 
-    def __stop_workers(self, n):
+    def _stop_workers(self, n):
 
         logger.debug("stopping %d workers", n)
 

--- a/examples/batch_task.py
+++ b/examples/batch_task.py
@@ -296,7 +296,7 @@ class BatchTask:
         )
 
         if check_fn is None:
-            check_fn = lambda b: self._default_check_fn(b)
+            check_fn = self._default_check_fn
 
         if self.overwrite:
             print("Dropping table %s" % self.db_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "tqdm",
   "funlib.math",
   "funlib.geometry",
+  "dill",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,5 +47,6 @@ module = [
     "funlib.*",
     "tqdm.*",
     "pkg_resources.*",
+    "dill",
 ]
 ignore_missing_imports = true

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import multiprocessing as mp
 from daisy.messages import AcquireBlock, ReleaseBlock, SendBlock, ExceptionMessage
 from daisy.tcp import TCPServer
 
+
 def run_test_server(block, conn):
     server = TCPServer()
     conn.send(server.address)
@@ -25,21 +26,20 @@ def run_test_server(block, conn):
     # handle return_block message
     message = server.get_message(timeout=1)
     try:
-        assert (isinstance(message, ReleaseBlock))
-        assert (message.block.status == daisy.BlockStatus.SUCCESS)
+        assert isinstance(message, ReleaseBlock)
+        assert message.block.status == daisy.BlockStatus.SUCCESS
     except Exception as e:
         message.stream.send_message(ExceptionMessage(e))
     conn.send(1)
     conn.close()
+
 
 def test_basic():
     roi = daisy.Roi((0, 0, 0), (10, 10, 10))
     task_id = 1
     block = daisy.Block(roi, roi, roi, block_id=1, task_id=task_id)
     parent_conn, child_conn = mp.Pipe()
-    server_process = mp.Process(
-        target=run_test_server, args=(block, child_conn)
-    )
+    server_process = mp.Process(target=run_test_server, args=(block, child_conn))
     server_process.start()
     host, port = parent_conn.recv()
     context = daisy.Context(hostname=host, port=port, task_id=task_id, worker_id=1)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,52 +4,49 @@ import multiprocessing as mp
 from daisy.messages import AcquireBlock, ReleaseBlock, SendBlock, ExceptionMessage
 from daisy.tcp import TCPServer
 
+def run_test_server(block, conn):
+    server = TCPServer()
+    conn.send(server.address)
 
-class TestClient(unittest.TestCase):
-
-    def run_test_server(self, block, conn):
-        server = TCPServer()
-        conn.send(server.address)
-
-        # handle first acquire_block message
-        message = None
-        for i in range(10):
-            message = server.get_message(timeout=1)
-            if message:
-                break
-        if not message:
-            raise Exception("SERVER COULDN'T GET MESSAGE")
-        try:
-            self.assertTrue(isinstance(message, AcquireBlock))
-            message.stream.send_message(SendBlock(block))
-        except Exception as e:
-            message.stream.send_message(ExceptionMessage(e))
-
-        # handle return_block message
+    # handle first acquire_block message
+    message = None
+    for i in range(10):
         message = server.get_message(timeout=1)
-        try:
-            self.assertTrue(isinstance(message, ReleaseBlock))
-            self.assertTrue(message.block.status == daisy.BlockStatus.SUCCESS)
-        except Exception as e:
-            message.stream.send_message(ExceptionMessage(e))
-        conn.send(1)
-        conn.close()
+        if message:
+            break
+    if not message:
+        raise Exception("SERVER COULDN'T GET MESSAGE")
+    try:
+        assert isinstance(message, AcquireBlock)
+        message.stream.send_message(SendBlock(block))
+    except Exception as e:
+        message.stream.send_message(ExceptionMessage(e))
 
-    def test_basic(self):
-        roi = daisy.Roi((0, 0, 0), (10, 10, 10))
-        task_id = 1
-        block = daisy.Block(roi, roi, roi, block_id=1, task_id=task_id)
-        parent_conn, child_conn = mp.Pipe()
-        server_process = mp.Process(
-            target=self.run_test_server, args=(block, child_conn)
-        )
-        server_process.start()
-        host, port = parent_conn.recv()
-        context = daisy.Context(hostname=host, port=port, task_id=task_id, worker_id=1)
-        client = daisy.Client(context=context)
-        with client.acquire_block() as block:
-            block.status = daisy.BlockStatus.SUCCESS
+    # handle return_block message
+    message = server.get_message(timeout=1)
+    try:
+        assert (isinstance(message, ReleaseBlock))
+        assert (message.block.status == daisy.BlockStatus.SUCCESS)
+    except Exception as e:
+        message.stream.send_message(ExceptionMessage(e))
+    conn.send(1)
+    conn.close()
 
-        success = parent_conn.recv()
-        server_process.join()
-        self.assertTrue(success)
+def test_basic():
+    roi = daisy.Roi((0, 0, 0), (10, 10, 10))
+    task_id = 1
+    block = daisy.Block(roi, roi, roi, block_id=1, task_id=task_id)
+    parent_conn, child_conn = mp.Pipe()
+    server_process = mp.Process(
+        target=run_test_server, args=(block, child_conn)
+    )
+    server_process.start()
+    host, port = parent_conn.recv()
+    context = daisy.Context(hostname=host, port=port, task_id=task_id, worker_id=1)
+    client = daisy.Client(context=context)
+    with client.acquire_block() as block:
+        block.status = daisy.BlockStatus.SUCCESS
+
+    success = parent_conn.recv()
+    server_process.join()
+    assert success

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,26 +5,25 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-class TestServer(unittest.TestCase):
+def process_block(block):
+    print("Processing block %s" % block)
 
-    def test_basic(self):
+def test_basic():
 
-        task = daisy.Task(
-            "test_server_task",
-            total_roi=daisy.Roi((0,), (100,)),
-            read_roi=daisy.Roi((0,), (10,)),
-            write_roi=daisy.Roi((1,), (8,)),
-            process_function=lambda b: self.process_block(b),
-            check_function=None,
-            read_write_conflict=True,
-            fit="valid",
-            num_workers=1,
-            max_retries=2,
-            timeout=None,
-        )
+    task = daisy.Task(
+        "test_server_task",
+        total_roi=daisy.Roi((0,), (100,)),
+        read_roi=daisy.Roi((0,), (10,)),
+        write_roi=daisy.Roi((1,), (8,)),
+        process_function=process_block,
+        check_function=None,
+        read_write_conflict=True,
+        fit="valid",
+        num_workers=1,
+        max_retries=2,
+        timeout=None,
+    )
 
-        server = daisy.Server()
-        server.run_blockwise([task])
+    server = daisy.Server()
+    server.run_blockwise([task])
 
-    def process_block(self, block):
-        print("Processing block %s" % block)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,6 +8,7 @@ logging.basicConfig(level=logging.DEBUG)
 def process_block(block):
     print("Processing block %s" % block)
 
+
 def test_basic():
 
     task = daisy.Task(
@@ -26,4 +27,3 @@ def test_basic():
 
     server = daisy.Server()
     server.run_blockwise([task])
-


### PR DESCRIPTION
# Make daisy run on Mac without necessitating `multiprocessing.set_start_method("fork", force=True)`

changes made:
1) removed all lambda functions
2) remove double underscore methods
3) use `dill` to pickle `spawn_function` in the `Worker` class (performance impacts unknown)
4) improved signature parsing for task `process_function`

## Running daisy with start method `spawn`:
### `if __name__ == "__main__":`
`daisy.run_blockwise` must be run from within a `if __name__ == "__main__":` block. Otherwise you will probably get this error:

> RuntimeError: 
> An attempt has been made to start a new process before the
> current process has finished its bootstrapping phase.
> 
> This probably means that you are not using fork to start your
> child processes and you have forgotten to use the proper idiom
> in the main module: ...

### `functools.partial`
We can't use `lambda` functions as the `process_function`. If you have a function e.g. `smooth(block, sigma)`, that you want to run for all `sigma` in `[1, 5, 9]`, you have to use `functools.partial` to define a function with the arguments you want. so `process_function = partial(smooth, sigma=1)`

Here is an example that should run on mac just fine with start method "spawn":
```python
import daisy

from functools import partial


def process_block(block,t):
    import time
    time.sleep(t)

if __name__ == "__main__":

    for t in range(3):

        task = daisy.Task(
            f"test_server_task_t{t}",
            total_roi=daisy.Roi((0,), (100,)),
            read_roi=daisy.Roi((0,), (10,)),
            write_roi=daisy.Roi((1,), (8,)),
            process_function=partial(process_block, t=t/10),
            check_function=None,
            read_write_conflict=True,
            fit="valid",
            num_workers=1,
            max_retries=2,
            timeout=None,
        )
    
        daisy.run_blockwise([task])
```