### PR TITLE
Fix PEP 765 SyntaxError

### DIFF
--- a/daisy/tcp/tcp_client.py
+++ b/daisy/tcp/tcp_client.py
@@ -146,9 +146,11 @@ class TCPClient(IOLooper):
                     # our side and break out of event loop
                     try:
                         self.stream.close()
+                    except BaseException:
+                        pass
                     finally:
                         self.stream = None
-                        return
+                    return
 
                 else:
                     self.message_queue.put(message)
@@ -157,7 +159,9 @@ class TCPClient(IOLooper):
                 try:
                     self.exception_queue.put(e)
                     self.stream.close()
+                except BaseException:
+                    pass
                 finally:
                     # mark client as disconnected
                     self.stream = None
-                    return
+                return

--- a/daisy/tcp/tcp_server.py
+++ b/daisy/tcp/tcp_server.py
@@ -114,9 +114,11 @@ class TCPServer(tornado.tcpserver.TCPServer, IOLooper):
             except Exception as e:
                 try:
                     self.exception_queue.put(e)
+                except BaseException:
+                    pass
                 finally:
                     self.client_streams.remove(stream)
-                    return
+                return
 
     def _check_for_errors(self):
         try:


### PR DESCRIPTION
This preserves the original intent of suppressing all exceptions while
being more explicit.

Motivation is cleaning up the logs of downstream daisy/volara workflows.

[PEP](peps.python.org/pep-0765/) and [associated guidance](https://github.com/iritkatriel/finally/blob/main/README.md).